### PR TITLE
Use MEI schema version 5.1

### DIFF
--- a/skeleton.mei
+++ b/skeleton.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-CMN.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-CMN.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
   <meiHead>
       <fileDesc>
           <titleStmt>


### PR DESCRIPTION
Update the template file to use the current MEI schema version 5.1. (The [MEI guidelines (5.1) §§1.1.2–1.1.3](https://music-encoding.org/guidelines/v5/content/introduction.html#aboutVersion5_1) contain high-level lists of changes since version 4.0.1.)